### PR TITLE
Part 1 - No code implementation

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,7 +64,7 @@ Events will be delivered at least once (dedup based on `message_id`) and may be 
 
 Your architecture should be able to handle at least 10k events per second in production environment.
 
-#### Implementation 1 : the best code is no code
+#### Implementation 1 : don't re-invent the wheel / the best code is no code
 
 I don't know if it is allowed but if facing this challenge in real life situation I would simply don't write this program and use off the shell program like [benthos](https://www.benthos.dev). This offer the ability to quickly have a program with everything needed to run in the cloud (health & ready probe, metrics, logger, signal handling, scale, purge of message at stop, ...).
 

--- a/benthos/config/http-input.yml
+++ b/benthos/config/http-input.yml
@@ -1,0 +1,85 @@
+http:
+  address: 0.0.0.0:4195
+  enabled: true
+
+logger:
+  level: INFO
+  format: logfmt
+  add_timestamp: true
+
+metrics:
+  prometheus: {}
+#  logger:
+#    push_interval: "5s"
+
+cache_resources:
+  - label: keycache
+    memory:
+      default_ttl: 60s
+
+input:
+  http_server:
+    address: "0.0.0.0:1234"
+    path: /events
+    allowed_verbs:
+      - POST
+    timeout: 15s
+
+
+# not ideal for delivery safety but needed for back-pressure on parquet local write (could be dissociate to guarantee delivery)
+# this could be improve by doing the parquet insert in a other daemon consuming from the queue at his rate.
+buffer: 
+  memory:
+    limit: 524288000 # 500M
+
+pipeline:
+  processors:
+    - dedupe:
+        cache: keycache
+        key: ${! json("message_id") }
+        drop_on_err: false
+
+output:
+  label: ""
+  broker:
+    pattern: fan_out # send to both parquet file and rabbitmq
+    outputs:
+    - amqp_0_9:
+        urls: 
+          - amqp://screeb:screeb@rabbitmq:5672/screeb
+        exchange: events
+        persistent: true
+        key: ${! json("message_id") }
+        type: "event"
+        content_encoding: "bytes"
+        content_type: "application/json"
+        max_in_flight: 1000
+        timeout: "1s"
+      processors:
+        - mapping:  meta = deleted() # remove http metadata to be cleared to send to rmq
+    # could be directly push to aws_s3:
+    - label: "parquet_column_data"
+      processors:
+        - mutation:  root.path = this.properties.path
+      broker:
+        outputs: 
+          - file:  
+              path: '/data/${! timestamp_unix() }-${! uuid_v4() }.parquet'
+              codec: all-bytes
+        batching:
+          count: 10000
+          period: 30s
+          processors:
+            - parquet_encode:
+                schema: # there is probably a better format
+                  - name: user_id
+                    type: BYTE_ARRAY
+                  - name: event_type
+                    type: BYTE_ARRAY
+                  - name: path
+                    type: BYTE_ARRAY
+                    optional: true
+                  - name: triggered_at
+                    type: BYTE_ARRAY
+                default_compression: uncompressed
+#                default_compression: zstd

--- a/benthos/data/.gitignore
+++ b/benthos/data/.gitignore
@@ -1,0 +1,4 @@
+# git keep
+*
+*/
+!.gitignore

--- a/benthos/docker-compose.yml
+++ b/benthos/docker-compose.yml
@@ -1,0 +1,14 @@
+version: '2.4'
+
+services:
+  benthos:
+    image: jeffail/benthos
+    volumes:
+      - ./config:/config
+      - ./data:/data
+    healthcheck:
+      test: ["CMD", "wget", "-q", "--spider", "http://localhost:4195/ready"]
+      interval: 5s
+      timeout: 3s
+      retries: 5
+      start_period: 3s

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -42,9 +42,9 @@ services:
     ports:
       - "5672:5672"
       - "15672:15672"
-    environment:
-      - RABBITMQ_DEFAULT_USER=screeb
-      - RABBITMQ_DEFAULT_PASS=screeb
+    volumes:
+      - ./docker/rabbitmq/rabbitmq.config:/etc/rabbitmq/rabbitmq.config
+      - ./docker/rabbitmq/definitions.json:/etc/rabbitmq/definitions.json
     healthcheck:
         test: ["CMD", "rabbitmq-diagnostics", "status", "-qs", "--formatter=json"]
         interval: 5s
@@ -83,3 +83,17 @@ services:
       KAFKA_ALLOW_EVERYONE_IF_NO_ACL_FOUND: "true"
     depends_on:
       - zookeeper
+
+  benthos:
+    extends:
+      file: benthos/docker-compose.yml
+      service: benthos
+    command: 
+      - "-c" 
+      - "/config/http-input.yml"
+    depends_on:
+      rabbitmq:
+        condition: service_healthy
+    ports:
+      - 1234:1234
+      - 4195:4195

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,4 +1,4 @@
-version: '3'
+version: '2.4' # seems conter intuitive but 2 version support helthcheck and not 3.
 
 services:
 
@@ -45,6 +45,12 @@ services:
     environment:
       - RABBITMQ_DEFAULT_USER=screeb
       - RABBITMQ_DEFAULT_PASS=screeb
+    healthcheck:
+        test: ["CMD", "rabbitmq-diagnostics", "status", "-qs", "--formatter=json"]
+        interval: 5s
+        timeout: 3s
+        retries: 5
+        start_period: 3s
 
   # https://github.com/conduktor/kafka-stack-docker-compose/blob/master/zk-single-kafka-single.yml
   zookeeper:

--- a/docker/rabbitmq/definitions.json
+++ b/docker/rabbitmq/definitions.json
@@ -1,0 +1,25 @@
+{
+    "users": [ 
+      { "name": "screeb", "password": "screeb", "tags": "administrator,monitoring,management" }
+    ],
+    "vhosts": [ 
+      { "name": "/" },
+      { "name": "screeb" }
+    ],
+    "permissions": [
+      { "user": "screeb", "vhost": "/", "configure": ".*", "write": ".*", "read": ".*"},
+      { "user": "screeb", "vhost": "screeb", "configure": ".*", "write": ".*", "read": ".*"}
+    ],
+    "parameters": [],
+    "policies": [],
+    "exchanges": [
+      { "name": "events", "vhost": "screeb", "type": "fanout", "durable": true, "auto_delete": false, "internal": false, "arguments": {} }    
+    ],
+    "queues": [
+      { "name": "events", "vhost": "screeb", "durable": true, "auto_delete": false, "arguments": {} }    
+    ],
+    "bindings": [
+      { "source": "events", "vhost": "screeb", "destination": "events", "destination_type": "queue", "routing_key": "#", "arguments": {} }
+    ]
+  }
+  

--- a/docker/rabbitmq/rabbitmq.config
+++ b/docker/rabbitmq/rabbitmq.config
@@ -1,0 +1,14 @@
+[
+  {
+    rabbit,
+      [
+        { loopback_users, [] }
+      ]
+  },
+  {
+    rabbitmq_management,
+      [
+        { load_definitions, "/etc/rabbitmq/definitions.json" }
+      ]
+  }
+].


### PR DESCRIPTION
I don't know if it is allowed but if facing this challenge in real life situation I would simply don't write this program and use off the shell program like [benthos](https://www.benthos.dev). This offer the ability to quickly have a program with everything needed to run in the cloud (health & ready probe, metrics, logger, signal handling, scale, purge of message at stop, ...).

So in this logic I implemented with the bonus (OLAP) parquet file dump that could be push directly by benthos to s3 or gcs bucket in production deployment.

I understand that it may not be what you expected for this part so let me know and I can redo it in code.

To start it :
```bash
# start benthos and dependencies (rabbitmq)
docker-compose up benthos
# send HTTP calls
go run *.go   --requests 10000        --concurrency 100       --url-cardinality 1000000   --endpoint-url http://localhost:1234/event
# message should be deduplicate in rabbitmq and we can extract some data from parquet files:
dsq --pretty benthos/data/*.parquet 'select User_id, count(*), GROUP_CONCAT(Path) from {0} WHERE Event_type = "page" GROUP BY User_id HAVING count(*) > 1 ORDER BY count(*)'
# cleanup
docker-compose down && rm docker-compose benthos/data/*.parquet 
```

